### PR TITLE
feat(game): implement dual-ticker game loop with gravity system

### DIFF
--- a/game/game.go
+++ b/game/game.go
@@ -179,18 +179,39 @@ func (g *Game) Reset() {
 	g.spawnPiece()
 }
 
-// Update updates the game state based on elapsed time
-func (g *Game) Update() {
+// CalculateGravityInterval returns the drop interval for a given level
+// Uses exponential decay: starts at 1000ms at level 1, goes down to 100ms at level 10+
+func CalculateGravityInterval(level int) time.Duration {
+	if level <= 0 {
+		level = 1
+	}
+	
+	// Exponential decay formula: interval = 1000 * 0.85^(level-1)
+	// Clamped to minimum of 100ms
+	interval := InitialDropInterval
+	for i := 1; i < level; i++ {
+		interval = int(float64(interval) * 0.85)
+		if interval < MinDropInterval {
+			interval = MinDropInterval
+			break
+		}
+	}
+	
+	return time.Duration(interval) * time.Millisecond
+}
+
+// ApplyGravity moves the current piece down one row (called by gravity ticker)
+func (g *Game) ApplyGravity() {
 	if g.paused || g.gameOver {
 		return
 	}
-	
-	// Check if it's time to drop the piece
-	now := time.Now()
-	if now.Sub(g.lastDropTime) >= g.dropInterval {
-		g.MoveDown()
-		g.lastDropTime = now
-	}
+	g.MoveDown()
+}
+
+// Update updates the game state (called each frame)
+func (g *Game) Update() {
+	// Frame-based updates can go here if needed
+	// Gravity is now handled by the gravity ticker calling ApplyGravity()
 }
 
 // MoveLeft moves the current piece left if possible

--- a/main.go
+++ b/main.go
@@ -33,40 +33,85 @@ func main() {
 	// Start input handling
 	inputHandler.Start()
 	
-	// Ensure cleanup on exit
-	defer inputHandler.Stop()
+	// Ensure cleanup on exit with panic recovery
+	defer func() {
+		if r := recover(); r != nil {
+			// Ensure terminal cleanup even on panic
+			inputHandler.Stop()
+			fmt.Fprintf(os.Stderr, "Panic recovered: %v\n", r)
+			os.Exit(1)
+		}
+		inputHandler.Stop()
+	}()
 	
 	// Create new game
 	gameState := game.New()
 	
-	// Main game loop
+	// Run the game loop
+	runGameLoop(gameState, inputHandler, screen)
+}
+
+// runGameLoop implements the main game loop with frame and gravity tickers
+func runGameLoop(gameState *game.Game, inputHandler *input.Handler, screen interface{ Show() }) {
+	// Initialize frame ticker for consistent 60 FPS
+	frameTicker := time.NewTicker(FrameDuration)
+	defer frameTicker.Stop()
+	
+	// Initialize gravity ticker based on starting level
+	gravityInterval := game.CalculateGravityInterval(gameState.GetLevel())
+	gravityTicker := time.NewTicker(gravityInterval)
+	defer gravityTicker.Stop()
+	
+	// Track game state for ticker management
+	lastLevel := gameState.GetLevel()
+	wasPaused := gameState.IsPaused()
 	running := true
-	lastFrameTime := time.Now()
 	
 	for running {
-		frameStart := time.Now()
-		
-		// Process input events
 		select {
+		case <-frameTicker.C:
+			// Frame tick: update and render
+			gameState.Update()
+			renderer.Render(screen, gameState)
+			
+			// Check if level changed and adjust gravity speed
+			currentLevel := gameState.GetLevel()
+			if currentLevel != lastLevel {
+				lastLevel = currentLevel
+				gravityTicker.Stop()
+				gravityInterval = game.CalculateGravityInterval(currentLevel)
+				gravityTicker = time.NewTicker(gravityInterval)
+				defer gravityTicker.Stop()
+			}
+			
+			// Handle pause state changes
+			isPaused := gameState.IsPaused()
+			if isPaused != wasPaused {
+				wasPaused = isPaused
+				if isPaused {
+					// Stop gravity ticker when paused
+					gravityTicker.Stop()
+				} else {
+					// Resume gravity ticker when unpaused
+					gravityInterval = game.CalculateGravityInterval(currentLevel)
+					gravityTicker = time.NewTicker(gravityInterval)
+					defer gravityTicker.Stop()
+				}
+			}
+			
+		case <-gravityTicker.C:
+			// Gravity tick: apply automatic piece drop
+			if !gameState.IsPaused() && !gameState.IsGameOver() {
+				gameState.ApplyGravity()
+			}
+			
 		case action := <-inputHandler.Actions():
+			// Input event: handle user action
 			running = handleAction(gameState, action)
-		default:
-			// No input to process
+			if !running {
+				return
+			}
 		}
-		
-		// Update game state
-		gameState.Update()
-		
-		// Render current state
-		renderer.Render(screen, gameState)
-		
-		// Frame rate limiting
-		elapsed := time.Since(frameStart)
-		if elapsed < FrameDuration {
-			time.Sleep(FrameDuration - elapsed)
-		}
-		
-		lastFrameTime = frameStart
 	}
 }
 


### PR DESCRIPTION
- Add frame ticker for consistent 60 FPS rendering (16.67ms)
- Add gravity ticker for automatic piece drops with level-based speed
- Implement CalculateGravityInterval() with exponential decay (1000ms at level 1, 100ms at level 10+)
- Replace time-based Update() with ApplyGravity() method for gravity ticks
- Refactor main.go to use runGameLoop() with select statement for multiple tickers
- Add dynamic gravity speed adjustment when level changes
- Implement pause state handling that stops/resumes gravity ticker
- Add panic recovery to ensure terminal cleanup on errors
- Properly defer all ticker stops and input handler cleanup
- Separate frame updates (Update) from gravity application (ApplyGravity)

BREAKING CHANGE: Game.Update() no longer handles gravity internally